### PR TITLE
Fix logic to get score and fps in GPU perf app

### DIFF
--- a/apps/gpu_performance.qml
+++ b/apps/gpu_performance.qml
@@ -344,7 +344,9 @@ Rectangle {
             }
             Timer {
                 id: timer
-                interval: 102000
+                /* The time duration needs to be more than the duration of
+                   running the glmark2 benchmark */
+                interval: 32000
                 running: false
                 repeat: false
                 onTriggered: {

--- a/backend/benchmarks.cpp
+++ b/backend/benchmarks.cpp
@@ -4,10 +4,10 @@ using namespace std;
 bool isfirsttime=1;
 QString stdout1;
 QProcess process1,gpuprocess;
-QFile file("/home/weston/log.txt");
+QFile file("/opt/ti-apps-launcher/glmark2-log.txt");
 void Benchmarks::playbutton1pressed() {
-    gpuprocess.setStandardOutputFile("/home/weston/temp.txt");
-    gpuprocess.start("glmark2-es2-wayland -b build:duration=10");
+    gpuprocess.setStandardOutputFile("/opt/ti-apps-launcher/glmark2-temp-log.txt");
+    gpuprocess.start("glmark2-es2-wayland -b build:duration=30");
 }
 
 bool Benchmarks::islogavl() {
@@ -26,23 +26,34 @@ bool Benchmarks::islogavl() {
 void Benchmarks::playbutton1pressedagain() {
     gpuprocess.kill();
     gpuprocess.waitForFinished(-1);
-    process1.start("rm /home/weston/temp.txt");
+    process1.start("rm /opt/ti-apps-launcher/glmark2-temp-log.txt");
 }
 void Benchmarks::playedcompletely() {
-    process1.start("mv /home/weston/temp.txt /home/weston/log.txt");
+    process1.start("mv /opt/ti-apps-launcher/glmark2-temp-log.txt /opt/ti-apps-launcher/glmark2-log.txt");
     process1.waitForFinished(-1);
-    //process1.start("rm /home/weston/temp.txt");
-    //process1.waitForFinished(-1);
 }
 QString Benchmarks::playbutton1fps() {
     file.open(QIODevice::ReadOnly);
     stdout1 = file.readAll();
     file.close();
-    //qDebug()<<stdout1;
-    return stdout1.mid(stdout1.indexOf("FPS")+5,4);
+    // Index of actual score comes 5 indices after index of "F". Ex: FPS: <FPS>
+    int index = stdout1.indexOf("FPS")+5;
+    QString res;
+    for(int i = index; stdout1[i] != ' ' && stdout1[i] != '\n'; i++)
+    {
+        res.append(stdout1[i]);
+    }
+    return res;
 }
 QString Benchmarks::playbutton1score() {
-    return stdout1.mid(stdout1.indexOf("Score")+7,4);
+    // Index of actual score comes 7 indices after index of "S". Ex: Score: <Score>
+    int index = stdout1.indexOf("Score") + 7;
+    QString res;
+    for(int i = index; stdout1[i] != ' ' && stdout1[i] != '\n'; i++)
+    {
+        res.append(stdout1[i]);
+    }
+    return res;
 }
 
 QProcess systembenchmarks;

--- a/backend/gpu_performance.cpp
+++ b/backend/gpu_performance.cpp
@@ -9,35 +9,52 @@ void Gpu_performance::gpuload0(){
 void Gpu_performance::gpuload1(){
     gpuload0();
     load.waitForFinished();
-    load.start("glmark2-es2-wayland -b buffer:duration=100");
+    /* The duration of the benchmark has to be tied to the time interval of the
+       Timer in the gpu_performance.qml. This is because we are reading the standard
+       output in the timer task */
+    load.start("glmark2-es2-wayland -b buffer:duration=30");
 }
 
 void Gpu_performance::gpuload2(){
     gpuload0();
     load.waitForFinished();
-    load.start("glmark2-es2-wayland -b ideas:duration=100");
+    load.start("glmark2-es2-wayland -b ideas:duration=30");
 }
 
 void Gpu_performance::gpuload3(){
     gpuload0();
     load.waitForFinished();
-    load.start("glmark2-es2-wayland -b texture:duration=100");
+    load.start("glmark2-es2-wayland -b texture:duration=30");
 }
 
 void Gpu_performance::gpuload4(){
     gpuload0();
     load.waitForFinished();
-    load.start("glmark2-es2-wayland -b terrain:duration=100");
+    load.start("glmark2-es2-wayland -b terrain:duration=30");
 }
 
+// To read Standard output
 QString loadout;
+
 QString Gpu_performance::getfps(){
     loadout = load.readAllStandardOutput();
-    /* Index of actual score comes 5 indices after index of "F". Ex: FPS: <FPS> */
-    return loadout.mid(loadout.indexOf("FPS")+5,4);
+    // Index of actual score comes 5 indices after index of "F". Ex: FPS: <FPS>
+    int index = loadout.indexOf("FPS")+5;
+    QString res;
+    for(int i = index; loadout[i] != ' ' && loadout[i] != '\n'; i++)
+    {
+        res.append(loadout[i]);
+    }
+    return res;
 }
 
 QString Gpu_performance::getscore(){
-    /* Index of actual score comes 7 indices after index of "S". Ex: Score: <Score> */
-    return loadout.mid(loadout.indexOf("Score")+7,4);
+    // Index of actual score comes 7 indices after index of "S". Ex: Score: <Score>
+    int index = loadout.indexOf("Score")+7;
+    QString res;
+    for(int i= index ; loadout[i] != ' ' && loadout[i] != '\n'; i++)
+    {
+        res.append(loadout[i]);
+    }
+    return res;
 }


### PR DESCRIPTION
- Reduced time for running glmark2 benchmarks to 30 seconds
- Change the location for the log file from glmarks