### PR TITLE
AM62x Family: Fix DDR bandwidth calculations

### DIFF
--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -1,0 +1,89 @@
+/* Configuration file for AM62x and AM62x-LP */
+
+#include <iostream>
+#include "backend/includes/common.h"
+#include "backend/includes/live_camera.h"
+#include "backend/includes/arm_analytics.h"
+#include "backend/includes/run_cmd.h"
+#include "backend/includes/settings.h"
+#include "backend/includes/gpu_performance.h"
+#include "backend/includes/benchmarks.h"
+
+#define PLATFORM "am62xx-lp-evm"
+using namespace std;
+int include_apps_count = 9;
+QString platform = "am62xx-lp-evm";
+
+app_info include_apps[] = {
+    {
+        .qml_source = "industrial_control.qml",
+        .name = "Industrial HMI",
+        .icon_source = "qrc:/images/hmi.png"
+    },
+    {
+        .qml_source = "live_camera.qml",
+        .name = "Live Camera",
+        .icon_source = "qrc:/images/camera.png"
+    },
+    {
+        .qml_source = "arm_analytics.qml",
+        .name = "ARM Analytics",
+        .icon_source = "qrc:/images/analytics.png"
+    },
+    {
+        .qml_source = "benchmarks.qml",
+        .name = "Benchmarks",
+        .icon_source = "qrc:/images/benchmarks.png"
+    },
+    {
+        .qml_source = "gpu_performance.qml",
+        .name = "GPU Performance",
+        .icon_source = "qrc:/images/gpu_performance.png"
+    },
+    {
+        .qml_source = "seva_store.qml",
+        .name = "Seva Store",
+        .icon_source = "qrc:/images/seva_store.png"
+    },
+    {
+        .qml_source = "firefox_browser.qml",
+        .name = "Firefox",
+        .icon_source = "qrc:/images/firefox.png"
+    },
+    {
+        .qml_source = "3d_demo.qml",
+        .name = "3D Demo",
+        .icon_source = "qrc:/images/3d.png"
+    },
+    {
+        .qml_source = "settings.qml",
+        .name = "Settings",
+        .icon_source = "qrc:/images/settings.png"
+    }
+};
+
+Settings settings;
+LiveCamera live_camera;
+ArmAnalytics arm_analytics;
+Benchmarks benchmarks;
+Gpu_performance gpuperformance;
+
+QString seva_command = QString::fromStdString("seva-launcher-aarch64");
+RunCmd *seva_store = new RunCmd(seva_command);
+RunCmd *firefox_browser = new RunCmd(QStringLiteral("docker run -v /run/user/1000/:/tmp/ -i --env http_proxy --env https_proxy --env no_proxy --env XDG_RUNTIME_DIR=/tmp/ --env WAYLAND_DISPLAY=wayland-1 -u user ghcr.io/texasinstruments/seva-browser:v1.0.0 https://www.ti.com/microcontrollers-mcus-processors/arm-based-processors/overview.html"));
+RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
+
+void platform_setup(QQmlApplicationEngine *engine) {
+    std::cout << "Running Platform Setup of AM62x!" << endl;
+    engine->rootContext()->setContextProperty("live_camera", &live_camera);
+    engine->rootContext()->setContextProperty("arm_analytics", &arm_analytics);
+    engine->rootContext()->setContextProperty("seva_store", seva_store);
+    engine->rootContext()->setContextProperty("firefox_browser", firefox_browser);
+    engine->rootContext()->setContextProperty("demo_3d", demo_3d);
+    engine->rootContext()->setContextProperty("settings", &settings);
+    engine->rootContext()->setContextProperty("benchmarks", &benchmarks);
+    engine->rootContext()->setContextProperty("gpuperformance", &gpuperformance);
+
+    docker_load_images();
+}
+

--- a/utils/perf_stats.cpp
+++ b/utils/perf_stats.cpp
@@ -145,11 +145,11 @@ void perfStatsCpuStatsPrint(perfStatsCpuLoad *cpu_load)
 #define PERF_DDR_MHZ                (2133u)  /* DDR clock speed in MHZ */
 #elif defined (SOC_AM62A)
 #define PERF_DDR_MHZ                (1866u)  /* DDR clock speed in MHZ */
-#elif defined (SOC_AM62)
+#elif defined (SOC_AM62) || defined (SOC_AM62_LP)
 #define PERF_DDR_MHZ                (800u)  /* DDR clock speed in MHZ */
 #endif
 
-#if defined (SOC_AM62)
+#if defined (SOC_AM62) || defined (SOC_AM62_LP)
 #define PERF_DDR_BUS_WIDTH          (  16u)  /* in units of bits */
 #else
 #define PERF_DDR_BUS_WIDTH          (  32u)  /* in units of bits */
@@ -158,6 +158,8 @@ void perfStatsCpuStatsPrint(perfStatsCpuLoad *cpu_load)
 #if defined(SOC_J721E) || defined(SOC_J721S2) || defined(SOC_J784S4) || defined(SOC_AM62A)
 #define PERF_DDR_BURST_SIZE_BYTES   (  64u)  /* in units of bytes */
 #elif defined (SOC_AM62)
+#define PERF_DDR_BURST_SIZE_BYTES   (  16u)  /* in units of bytes */
+#elif defined (SOC_AM62_LP)
 #define PERF_DDR_BURST_SIZE_BYTES   (  32u)  /* in units of bytes */
 #endif
 
@@ -167,7 +169,7 @@ void perfStatsCpuStatsPrint(perfStatsCpuLoad *cpu_load)
 #define PERF_DDR_STATS_CTR2         (0x03) /* A value of 0x03 configures counter 3 to return number of command activations */
 #define PERF_DDR_STATS_CTR3         (0x1C) /* A value of 0x1C configures counter 4 to return number of queue full states   */
 
-#if defined(SOC_J721E) || defined(SOC_AM62A) || defined(SOC_AM62)
+#if defined(SOC_J721E) || defined(SOC_AM62A) || defined(SOC_AM62) || defined (SOC_AM62_LP)
 #define PERF_NUM_DDR_INSTANCES      (1u)
 #elif defined (SOC_J721S2)
 #define PERF_NUM_DDR_INSTANCES      (2u)
@@ -239,7 +241,7 @@ void perfStatsDdrStatsReadCounters(uint32_t *val0, uint32_t *val1, uint32_t *val
         fd = open("/dev/mem", O_RDWR | O_SYNC);
         base = mmap(0, 0xF400000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0x0);
 
-        #if defined(SOC_AM62A) || defined(SOC_AM62)
+        #if defined(SOC_AM62A) || defined(SOC_AM62) || defined (SOC_AM62_LP)
         cnt_sel[0] = (volatile uint32_t *)(base + 0x0f300000);
         cnt0[0]    = (volatile uint32_t *)(base + 0x0f300104);
         cnt1[0]    = (volatile uint32_t *)(base + 0x0f300108);
@@ -406,3 +408,4 @@ void perfStatsDdrStatsPrintAll()
         ddr_load->read_bw_avg+ddr_load->write_bw_avg);
     printf("\n");
 }
+


### PR DESCRIPTION
The AM62x has a DDR4 and the AM62x-LP has a LPDDR4. The DDR_BURST_SIZE is different for both (16 and 32 respectively). So to differentiate these two, create a separate config for AM62x-LP and update the perf_stats.cpp accordingly.