### PR TITLE
Stats: Read and Display SoC temperature from thermal nodes

### DIFF
--- a/apps/stats.qml
+++ b/apps/stats.qml
@@ -14,19 +14,13 @@ Rectangle {
     id: statswindow
     visible: true
     color: "#17252A"
+
     Rectangle {
         id: backgroundrect
         width: statswindow.width
         height: statswindow.height
         color: "#344045"
-        /*
-        Image {
-            id: backgroundimage
-            source:"../images/Background.png"
-            width: parent.width
-            height: parent.height
-        }
-        */
+
         Rectangle {
             id: gpubar
             width: parent.width * 0.05
@@ -36,6 +30,7 @@ Rectangle {
             anchors.topMargin: parent.height * 0.1
             anchors.left: parent.left
             anchors.leftMargin: parent.width * 0.05
+
             Rectangle {
                 id: gpubarfill
                 color: "steelblue"
@@ -43,6 +38,7 @@ Rectangle {
                 height: 0
                 anchors.bottom: parent.bottom
             }
+
             Text {
                 id: gpuload
                 text: qsTr("0%")
@@ -51,6 +47,7 @@ Rectangle {
                 font.bold: true
                 anchors.centerIn: parent
             }
+
             Timer {
                 interval: 1000 // interval in milliseconds
                 running: true // start the timer
@@ -62,6 +59,7 @@ Rectangle {
                 }
             }
         }
+
         Rectangle {
             width: parent.width * 0.080
             height: parent.height * 0.8 * 0.2
@@ -78,6 +76,7 @@ Rectangle {
                 anchors.centerIn: parent
             }
         }
+
         Rectangle {
             id: cpubar
             width: parent.width * 0.05
@@ -87,6 +86,7 @@ Rectangle {
             anchors.topMargin: parent.height * 0.1
             anchors.left: gpubar.right
             anchors.leftMargin: parent.width * 0.05
+
             Rectangle {
                 id: cpubarfill
                 color: "steelblue"
@@ -94,6 +94,7 @@ Rectangle {
                 height: 0
                 anchors.bottom: parent.bottom
             }
+
             Text {
                 id: cpuload
                 text: qsTr("0")
@@ -102,6 +103,7 @@ Rectangle {
                 font.bold: true
                 anchors.centerIn: parent
             }
+
             Timer {
                 interval: 1000 // interval in milliseconds
                 running: true // start the timer
@@ -113,6 +115,7 @@ Rectangle {
                 }
             }
         }
+
         Rectangle {
             width: parent.width * 0.080
             height: parent.height * 0.8 * 0.2
@@ -122,13 +125,13 @@ Rectangle {
             anchors.leftMargin: parent.width * 0.135
 
             Text {
-                
                 text: qsTr("CPU Load")
                 color: "#FFFFFF"
                 font.pixelSize: parent.width * 0.12
                 anchors.centerIn: parent
             }
         }
+
         Rectangle {
             id: ddrbar
             width: parent.width * 0.05
@@ -139,6 +142,7 @@ Rectangle {
             anchors.left: cpubar.right
             anchors.leftMargin: parent.width * 0.05
             property int totalbw: statsbackend.getddrtotalbw()
+
             Rectangle {
                 id: ddrbarfill
                 color: "steelblue"
@@ -146,6 +150,7 @@ Rectangle {
                 height: 0
                 anchors.bottom: parent.bottom
             }
+
             Rectangle {
                 id: ddrwritebw
                 color: "red"
@@ -153,6 +158,7 @@ Rectangle {
                 height: 0
                 anchors.bottom: parent.bottom
             }
+
             Rectangle {
                 id: ddrreadbw
                 color: "yellow"
@@ -160,6 +166,7 @@ Rectangle {
                 height: 0
                 anchors.bottom: ddrwritebw.top
             }
+
             Text {
                 id: ddrload
                 text: qsTr("0")
@@ -168,6 +175,7 @@ Rectangle {
                 font.bold: true
                 anchors.centerIn: parent
             }
+
             Text {
                 text: qsTr("MB/S")
                 color: "#F44336"
@@ -176,20 +184,22 @@ Rectangle {
                 font.bold: true
                 anchors.top: ddrload.bottom
             }
+
             Timer {
                 interval: 1000 // interval in milliseconds
                 running: true // start the timer
                 repeat: true // repeat the timer
+
                 onTriggered: {
                     ddrload.text = statsbackend.getddrload()
-                    readbw.text = statsbackend.getddrreadbw() 
+                    readbw.text = statsbackend.getddrreadbw()
                     writebw.text = statsbackend.getddrwritebw()
                     ddrreadbw.height = (readbw.text * ddrbar.height) /ddrbar.totalbw
                     ddrwritebw.height = (writebw.text * ddrbar.height) /ddrbar.totalbw
-                    
                 }
             }
         }
+
         Text {
             anchors.left: ddrbar.right
             anchors.leftMargin: parent.width * 0.005
@@ -199,6 +209,7 @@ Rectangle {
             color: "red"
             font.pixelSize: anchors.width * 0.2
         }
+
         Rectangle {
             id: writebwlegend
             height: parent.height * 0.2
@@ -207,6 +218,7 @@ Rectangle {
             anchors.bottom: ddrbar.bottom
             anchors.leftMargin: parent.width * 0.04
             color: "red"
+
             Text{
                 id: writebw
                 text: qsTr("0")
@@ -215,6 +227,7 @@ Rectangle {
                 font.pixelSize: parent.width * 0.3
             }
         }
+
         Text {
             anchors.left: ddrbar.right
             anchors.leftMargin: parent.width * 0.005
@@ -224,6 +237,7 @@ Rectangle {
             color: "yellow"
             font.pixelSize: anchors.width * 0.2
         }
+
         Rectangle {
             id: readbwlegend
             height: writebwlegend.height
@@ -232,6 +246,7 @@ Rectangle {
             anchors.bottom: writebwlegend.top
             anchors.bottomMargin: parent.height * 0.1
             color: "yellow"
+
             Text{
                 id: readbw
                 text: qsTr("0")
@@ -240,6 +255,7 @@ Rectangle {
                 font.pixelSize: parent.width * 0.3
             }
         }
+
         Rectangle {
             width: parent.width * 0.080
             height: parent.height * 0.8 * 0.2
@@ -254,5 +270,74 @@ Rectangle {
                 anchors.centerIn: parent
             }
         }
+
+        Rectangle {
+            id: tempbar
+            width: parent.width * 0.05
+            height: parent.height * 0.7
+            color: "#A0A0A0"
+            anchors.top: parent.top
+            anchors.topMargin: parent.height * 0.1
+            anchors.left: readbwlegend.right
+            anchors.leftMargin: parent.width * 0.05
+
+            Rectangle {
+                id: tempbarvalue
+                width: parent.width
+                height: 0
+                anchors.bottom: parent.bottom
+                clip: true
+
+                Rectangle {
+                    id: tempbarfill
+                    anchors.left: parent.left
+                    anchors.bottom: parent.bottom
+                    height: tempbar.height
+                    width: tempbar.width
+
+                    gradient: Gradient {
+                        GradientStop { position: 0.0; color: "red" }
+                        GradientStop { position: 0.33; color: "yellow" }
+                        GradientStop { position: 1.0; color: "green" }
+                    }
+                }
+            }
+
+            Text {
+                id: temperature
+                text: qsTr("0")
+                color: "#F44336"
+                font.pixelSize: parent.width * 0.24
+                font.bold: true
+                anchors.centerIn: parent
+            }
+
+            Timer {
+                interval: 1000 // interval in milliseconds
+                running: true // start the timer
+                repeat: true // repeat the timer
+                onTriggered: {
+                    temperature.text = statsbackend.get_soc_temp()
+                    tempbarvalue.height = temperature.text * tempbar.height / 150
+                    temperature.text = temperature.text + " °C"
+                }
+            }
+        }
+
+        Rectangle {
+            width: parent.width * 0.080
+            height: parent.height * 0.8 * 0.2
+            anchors.top: tempbar.bottom
+            color: "transparent"
+            anchors.horizontalCenter: tempbar.horizontalCenter
+
+            Text {
+                text: qsTr("SoC Temperature")
+                color: "#FFFFFF"
+                font.pixelSize: parent.width * 0.12
+                anchors.centerIn: parent
+            }
+        }
     }
 }
+

--- a/backend/includes/stats.h
+++ b/backend/includes/stats.h
@@ -20,8 +20,9 @@ public:
 
     Q_INVOKABLE QString getgpuload();
     Q_INVOKABLE QString getcpuload();
+    Q_INVOKABLE QString get_soc_temp();
     Q_INVOKABLE uint32_t getddrload();
-    Q_INVOKABLE uint32_t getddrtotalbw(); 
+    Q_INVOKABLE uint32_t getddrtotalbw();
     Q_INVOKABLE uint32_t getddrreadbw();
     Q_INVOKABLE uint32_t getddrwritebw();
 };

--- a/backend/stats.cpp
+++ b/backend/stats.cpp
@@ -26,6 +26,19 @@ QString stats::getcpuload() {
     return res;
 }
 
+QString stats::get_soc_temp() {
+    QProcess process;
+    QString output;
+    float temp = 0;
+
+    process.start("sudo cat /sys/class/thermal/thermal_zone0/temp");
+    process.waitForFinished(-1);
+    temp = process.readAllStandardOutput().toFloat();
+
+    // The temperature value returned is in millidegree celsius, so convert to celsius before sending to QML
+    return QString::number(temp / 1000, 'f', 2);
+}
+
 uint32_t stats::getddrtotalbw() {
     perf_stats_ddr_stats_t *ddrload;
     ddrload=perfStatsDdrStatsGet();


### PR DESCRIPTION
The thermal nodes /sys/class/thermal/thermal_zone*/temp allows us to read temperature of different thermal_zones within the SoC. Since all the thermal_zones will be at similar temperatures, only read the thermal_zone0 because it is common for all SoCs.

Display the value in the stats window as a gradient (Green, Yellow, Red).

If thermal_zones are not available, the value displayed will be 0 C.