### PR TITLE
Add initial support for AM62x-SIP and AM62Px platforms

### DIFF
--- a/configs/am62pxx-evm.cpp
+++ b/configs/am62pxx-evm.cpp
@@ -1,0 +1,44 @@
+/* Configuration file for AM62x and AM62x-LP */
+
+#include <iostream>
+#include "backend/includes/common.h"
+#include "backend/includes/settings.h"
+#include "backend/includes/gpu_performance.h"
+#include "backend/includes/benchmarks.h"
+
+#define PLATFORM "am62pxx-evm"
+using namespace std;
+int include_apps_count = 3;
+QString platform = "am62pxx-evm";
+
+app_info include_apps[] = {
+    {
+        .qml_source = "benchmarks.qml",
+        .name = "Benchmarks",
+        .icon_source = "qrc:/images/benchmarks.png"
+    },
+    {
+        .qml_source = "gpu_performance.qml",
+        .name = "GPU Performance",
+        .icon_source = "qrc:/images/gpu_performance.png"
+    },
+    {
+        .qml_source = "settings.qml",
+        .name = "Settings",
+        .icon_source = "qrc:/images/settings.png"
+    }
+};
+
+Settings settings;
+Benchmarks benchmarks;
+Gpu_performance gpuperformance;
+
+void platform_setup(QQmlApplicationEngine *engine) {
+    std::cout << "Running Platform Setup of AM62Px EVM!" << endl;
+    engine->rootContext()->setContextProperty("settings", &settings);
+    engine->rootContext()->setContextProperty("benchmarks", &benchmarks);
+    engine->rootContext()->setContextProperty("gpuperformance", &gpuperformance);
+
+    docker_load_images();
+}
+

--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -74,7 +74,7 @@ RunCmd *firefox_browser = new RunCmd(QStringLiteral("docker run -v /run/user/100
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 
 void platform_setup(QQmlApplicationEngine *engine) {
-    std::cout << "Running Platform Setup of AM62x!" << endl;
+    std::cout << "Running Platform Setup of AM62x LP EVM!" << endl;
     engine->rootContext()->setContextProperty("live_camera", &live_camera);
     engine->rootContext()->setContextProperty("arm_analytics", &arm_analytics);
     engine->rootContext()->setContextProperty("seva_store", seva_store);

--- a/configs/am62xx-sip-evm.cpp
+++ b/configs/am62xx-sip-evm.cpp
@@ -1,0 +1,44 @@
+/* Configuration file for AM62x and AM62x-LP */
+
+#include <iostream>
+#include "backend/includes/common.h"
+#include "backend/includes/settings.h"
+#include "backend/includes/gpu_performance.h"
+#include "backend/includes/benchmarks.h"
+
+#define PLATFORM "am62xx-sip-evm"
+using namespace std;
+int include_apps_count = 3;
+QString platform = "am62xx-sip-evm";
+
+app_info include_apps[] = {
+    {
+        .qml_source = "benchmarks.qml",
+        .name = "Benchmarks",
+        .icon_source = "qrc:/images/benchmarks.png"
+    },
+    {
+        .qml_source = "gpu_performance.qml",
+        .name = "GPU Performance",
+        .icon_source = "qrc:/images/gpu_performance.png"
+    },
+    {
+        .qml_source = "settings.qml",
+        .name = "Settings",
+        .icon_source = "qrc:/images/settings.png"
+    }
+};
+
+Settings settings;
+Benchmarks benchmarks;
+Gpu_performance gpuperformance;
+
+void platform_setup(QQmlApplicationEngine *engine) {
+    std::cout << "Running Platform Setup of AM62x SIP EVM!" << endl;
+    engine->rootContext()->setContextProperty("settings", &settings);
+    engine->rootContext()->setContextProperty("benchmarks", &benchmarks);
+    engine->rootContext()->setContextProperty("gpuperformance", &gpuperformance);
+
+    docker_load_images();
+}
+


### PR DESCRIPTION
- AM62x-SIP is a strip down version of AM62x platform with 512 Mb RAM. So most of the applications available won't work on this. So create a minimal config with only what will be functional. We also have to create a minimal industrial hmi application which is less intensive on memory.
- AM62P is another platform with a new and powerful SoC. The device bringup is still in progress so not all features are supported. So use a minimal config and enable applications as and when the baseport supports it.