### PR TITLE
configs: am62pxx-evm: Disable seva-store

### DIFF
--- a/configs/am62pxx-evm.cpp
+++ b/configs/am62pxx-evm.cpp
@@ -9,7 +9,7 @@
 
 #define PLATFORM "am62pxx-evm"
 using namespace std;
-int include_apps_count = 6;
+int include_apps_count = 5;
 QString platform = "am62pxx-evm";
 
 app_info include_apps[] = {
@@ -29,11 +29,6 @@ app_info include_apps[] = {
         .icon_source = "qrc:/images/gpu_performance.png"
     },
     {
-        .qml_source = "seva_store.qml",
-        .name = "Seva Store",
-        .icon_source = "qrc:/images/seva_store.png"
-    },
-    {
         .qml_source = "firefox_browser.qml",
         .name = "Firefox",
         .icon_source = "qrc:/images/firefox.png"
@@ -49,18 +44,18 @@ Settings settings;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-QString seva_command = QString::fromStdString("seva-launcher-aarch64");
-RunCmd *seva_store = new RunCmd(seva_command);
+/* QString seva_command = QString::fromStdString("seva-launcher-aarch64");
+RunCmd *seva_store = new RunCmd(seva_command); */
 RunCmd *firefox_browser = new RunCmd(QStringLiteral("docker run -v /run/user/1000/:/tmp/ -i --env http_proxy --env https_proxy --env no_proxy --env XDG_RUNTIME_DIR=/tmp/ --env WAYLAND_DISPLAY=wayland-1 -u user ghcr.io/texasinstruments/seva-browser:v1.0.0 https://www.ti.com/microcontrollers-mcus-processors/arm-based-processors/overview.html"));
 
 void platform_setup(QQmlApplicationEngine *engine) {
     std::cout << "Running Platform Setup of AM62P!" << endl;
-    engine->rootContext()->setContextProperty("seva_store", seva_store);
+    /*engine->rootContext()->setContextProperty("seva_store", seva_store);*/
     engine->rootContext()->setContextProperty("firefox_browser", firefox_browser);
     engine->rootContext()->setContextProperty("settings", &settings);
     engine->rootContext()->setContextProperty("benchmarks", &benchmarks);
     engine->rootContext()->setContextProperty("gpuperformance", &gpuperformance);
 
-    docker_load_images();
+    //docker_load_images();
 }
 


### PR DESCRIPTION
- Currently resize-rootfs init.d script isn't working on latest kirkstone filesystem due to which seva-store isn't functional as pulling > 2GB demo docker image isn't be possible due to less storage. Hence, disable seva-store in AM62P for now.