### PR TITLE
configs: am62xxsip-evm: Remove Docker Load

### DIFF
--- a/configs/am62xxsip-evm.cpp
+++ b/configs/am62xxsip-evm.cpp
@@ -38,7 +38,5 @@ void platform_setup(QQmlApplicationEngine *engine) {
     engine->rootContext()->setContextProperty("settings", &settings);
     engine->rootContext()->setContextProperty("benchmarks", &benchmarks);
     engine->rootContext()->setContextProperty("gpuperformance", &gpuperformance);
-
-    docker_load_images();
 }
 


### PR DESCRIPTION
- Seva Store via ti-apps-launcher isn't planned for AM62SIP. Hence, remove the browser load function needed for seva-browser.