### PR TITLE
Remove Camera app from SITARA Platforms

### DIFF
--- a/configs/am62xx-evm.cpp
+++ b/configs/am62xx-evm.cpp
@@ -11,7 +11,7 @@
 
 #define PLATFORM "am62xx-evm"
 using namespace std;
-int include_apps_count = 9;
+int include_apps_count = 8;
 QString platform = "am62xx-evm";
 QString wallpaper = "file:///opt/ti-apps-launcher/assets/am6x_oob_demo_home_image.png";
 
@@ -21,11 +21,13 @@ app_info include_apps[] = {
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
     },
+    /*
     {
         .qml_source = "live_camera.qml",
         .name = "Live Camera",
         .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
+    */
     {
         .qml_source = "arm_analytics.qml",
         .name = "ARM Analytics",

--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -11,7 +11,7 @@
 
 #define PLATFORM "am62xx-lp-evm"
 using namespace std;
-int include_apps_count = 9;
+int include_apps_count = 8;
 QString platform = "am62xx-lp-evm";
 QString wallpaper = "file:///opt/ti-apps-launcher/assets/am6x_oob_demo_home_image.png";
 
@@ -21,11 +21,13 @@ app_info include_apps[] = {
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
     },
+    /*
     {
         .qml_source = "live_camera.qml",
         .name = "Live Camera",
         .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
+    */
     {
         .qml_source = "arm_analytics.qml",
         .name = "ARM Analytics",

--- a/configs/am62xxsip-evm.cpp
+++ b/configs/am62xxsip-evm.cpp
@@ -9,7 +9,7 @@
 
 #define PLATFORM "am62xxsip-evm"
 using namespace std;
-int include_apps_count = 3;
+int include_apps_count = 2;
 QString platform = "am62xxsip-evm";
 QString wallpaper = "file:///opt/ti-apps-launcher/assets/am62sip_wallpaper.png";
 
@@ -19,11 +19,13 @@ app_info include_apps[] = {
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
     },
+    /*
     {
         .qml_source = "live_camera.qml",
         .name = "Live Camera",
         .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
+    */
     {
         .qml_source = "settings.qml",
         .name = "Settings",


### PR DESCRIPTION
Currently, CSI Camera -> GPU -> QT Videosink works but the video flickers and lots of memory errors are reported on the console by GPU PVR driver. So disable Camera application for now.

Note: The Camera Streaming still works with glimagesink, waylandsink and kmssink. Only qtvideosink is problematic.