### PR TITLE
ARM Analytics: Add dummy pipelines to fix compilation errors

### DIFF
--- a/backend/arm_analytics.cpp
+++ b/backend/arm_analytics.cpp
@@ -17,6 +17,12 @@ QString face_detection_gst_pipeline = "gst-pipeline: multifilesrc location=/opt/
 
 QString image_classification_gst_pipeline = "gst-pipeline: multifilesrc location=/opt/oob-demo-assets/oob-gui-video1.h264 loop=true caps=video/x-h264,width=1280,height=720,framerate=1/1 ! h264parse ! v4l2h264dec capture-io-mode=4 ! ticolorconvert ! video/x-raw, format=NV12 ! tee name=tee_split0 tee_split0. ! queue ! tiscaler roi-startx=80 roi-starty=45 roi-width=1120 roi-height=630 ! video/x-raw, width=224, height=224 ! tidlpreproc model=/opt/model_zoo/ONR-CL-6360-regNetx-200mf  out-pool-size=4 ! application/x-tensor-tiovx ! tidlinferer model=/opt/model_zoo/ONR-CL-6360-regNetx-200mf ! post_0.tensor tee_split0. ! queue ! post_0.sink tidlpostproc name=post_0 model=/opt/model_zoo/ONR-CL-6360-regNetx-200mf top-N=5 display-model=true ! video/x-raw,format=NV12, width=1280, height=720 ! qtvideosink sync=true";
 
+#else
+
+QString object_detection_gst_pipeline = "";
+QString face_detection_gst_pipeline = "";
+QString image_classification_gst_pipeline = "";
+
 #endif
 
 ArmAnalytics::ArmAnalytics() {


### PR DESCRIPTION
The compilation would fail for all SOCs for which the ifdefs do not cover the variable definitions. Add default empty strings as quick fix