### PR TITLE
Sitara Platforms: Add back live camera app

### DIFF
--- a/backend/live_camera.cpp
+++ b/backend/live_camera.cpp
@@ -106,8 +106,8 @@ QString LiveCamera::liveCamera_gst_pipeline() {
     gst_pipeline = "gst-pipeline: ";
     gst_pipeline.append("v4l2src device=");
     gst_pipeline.append(QString::fromStdString((cameraInfo[_camera.toStdString()]["device"])));
-    #if defined(SOC_AM62) || defined(SOC_AM62_LP)
-    gst_pipeline.append(" ! video/x-raw, width=640, height=480, format=YUY2");
+    #if defined(SOC_AM62) || defined(SOC_AM62_LP) || defined(SOC_AM62P)
+    gst_pipeline.append(" ! video/x-raw, width=640, height=480, format=UYVY");
     #elif defined(SOC_J721E) || defined(SOC_J721S2) || defined(SOC_J784S4)
     gst_pipeline.append(" ! image/jpeg, width=1280, height=720 ! jpegdec");
     #endif

--- a/configs/am62pxx-evm.cpp
+++ b/configs/am62pxx-evm.cpp
@@ -2,9 +2,10 @@
 
 #include <iostream>
 #include "backend/includes/common.h"
+#include "backend/includes/live_camera.h"
+#include "backend/includes/arm_analytics.h"
 #include "backend/includes/run_cmd.h"
 #include "backend/includes/settings.h"
-#include "backend/includes/arm_analytics.h"
 #include "backend/includes/gpu_performance.h"
 #include "backend/includes/benchmarks.h"
 
@@ -32,12 +33,17 @@ power_actions include_powerbuttons[] = {
     }
 };
 
-int include_apps_count = 9;
+int include_apps_count = 10;
 app_info include_apps[] = {
     {
         .qml_source = "industrial_control_sitara.qml",
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
+    },
+    {
+        .qml_source = "live_camera.qml",
+        .name = "Live Camera",
+        .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
     {
         .qml_source = "arm_analytics.qml",
@@ -82,9 +88,10 @@ app_info include_apps[] = {
 };
 
 Settings settings;
+LiveCamera live_camera;
+ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
-ArmAnalytics arm_analytics;
 
 QString seva_command = QString::fromStdString("seva-launcher-aarch64");
 RunCmd *seva_store = new RunCmd(seva_command);
@@ -95,10 +102,11 @@ RunCmd *poweraction = new RunCmd(QStringLiteral(""));
 
 void platform_setup(QQmlApplicationEngine *engine) {
     std::cout << "Running Platform Setup of AM62P!" << endl;
+    engine->rootContext()->setContextProperty("live_camera", &live_camera);
+    engine->rootContext()->setContextProperty("arm_analytics", &arm_analytics);
     engine->rootContext()->setContextProperty("seva_store", seva_store);
     engine->rootContext()->setContextProperty("firefox_browser", firefox_browser);
     engine->rootContext()->setContextProperty("demo_3d", demo_3d);
-    engine->rootContext()->setContextProperty("arm_analytics", &arm_analytics);
     engine->rootContext()->setContextProperty("settings", &settings);
     engine->rootContext()->setContextProperty("benchmarks", &benchmarks);
     engine->rootContext()->setContextProperty("gpuperformance", &gpuperformance);

--- a/configs/am62xx-evm.cpp
+++ b/configs/am62xx-evm.cpp
@@ -34,20 +34,18 @@ power_actions include_powerbuttons[] = {
 };
 
 
-int include_apps_count = 8;
+int include_apps_count = 9;
 app_info include_apps[] = {
     {
         .qml_source = "industrial_control_sitara.qml",
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
     },
-    /*
     {
         .qml_source = "live_camera.qml",
         .name = "Live Camera",
         .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
-    */
     {
         .qml_source = "arm_analytics.qml",
         .name = "ARM Analytics",

--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -28,20 +28,18 @@ power_actions include_powerbuttons[] = {
     }
 };
 
-int include_apps_count = 8;
+int include_apps_count = 9;
 app_info include_apps[] = {
     {
         .qml_source = "industrial_control_sitara.qml",
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
     },
-    /*
     {
         .qml_source = "live_camera.qml",
         .name = "Live Camera",
         .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
-    */
     {
         .qml_source = "arm_analytics.qml",
         .name = "ARM Analytics",

--- a/configs/am62xxsip-evm.cpp
+++ b/configs/am62xxsip-evm.cpp
@@ -27,20 +27,18 @@ power_actions include_powerbuttons[] = {
     }
 };
 
-int include_apps_count = 2;
+int include_apps_count = 3;
 app_info include_apps[] = {
     {
         .qml_source = "industrial_control_minimal.qml",
         .name = "Industrial HMI",
         .icon_source = "file:///opt/ti-apps-launcher/assets/hmi.png"
     },
-    /*
     {
         .qml_source = "live_camera.qml",
         .name = "Live Camera",
         .icon_source = "file:///opt/ti-apps-launcher/assets/camera.png"
     },
-    */
     {
         .qml_source = "settings.qml",
         .name = "Settings",


### PR DESCRIPTION
This reverts [96fb029](https://github.com/TexasInstruments/ti-apps-launcher/commit/96fb02984c260300d50d94c4bc66e122b7b3903f) while also adding Camera app support to the new AM62P platform.