### PR TITLE
remove usage of sudo

### DIFF
--- a/backend/settings.cpp
+++ b/backend/settings.cpp
@@ -12,27 +12,27 @@ unordered_map<string, string> proxy_list;
 
 void set_environment_variables() {
     // Setting up Environment Variables
-    string command = "echo https_proxy=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/environment";
+    string command = "echo https_proxy=" + proxy_list["https_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
-    command = "echo HTTPS_PROXY=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/environment";
+
+    command = "echo HTTPS_PROXY=" + proxy_list["https_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
-    command = "echo HTTP_PROXY=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/environment";
+
+    command = "echo HTTP_PROXY=" + proxy_list["https_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
-    command = "echo http_proxy=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/environment";
+
+    command = "echo http_proxy=" + proxy_list["https_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
-    command = "echo ftp_proxy=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/environment";
+
+    command = "echo ftp_proxy=" + proxy_list["https_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
-    command = "echo FTP_PROXY=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/environment";
+
+    command = "echo FTP_PROXY=" + proxy_list["https_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
-    command = "echo no_proxy=" + proxy_list["no_proxy"] + " | sudo tee -a /etc/environment";
+
+    command = "echo no_proxy=" + proxy_list["no_proxy"] + " | tee -a /etc/environment";
     system(command.c_str());
-    
+
     setenv("https_proxy",proxy_list["https_proxy"].c_str(),1);
     setenv("http_proxy",proxy_list["https_proxy"].c_str(),1);
     setenv("ftp_proxy",proxy_list["https_proxy"].c_str(),1);
@@ -45,30 +45,30 @@ void set_environment_variables() {
 
 void apply_docker_proxy() {
     // Create /etc/systemd/system/docker.service.d directory structure
-    if(system("sudo mkdir -p /etc/systemd/system/docker.service.d") == -1){
+    if(system("mkdir -p /etc/systemd/system/docker.service.d") == -1){
         cout << "Failed to create directory structure for docker proxies" << endl;
         exit(0);
     }
-    
+
     // Write the docker proxy setting
-    string apply_systemd_proxy = "echo [Service] | sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf";
+    string apply_systemd_proxy = "echo [Service] | tee /etc/systemd/system/docker.service.d/http-proxy.conf";
     system(apply_systemd_proxy.c_str());
-    
-    apply_systemd_proxy = "echo Environment=HTTPS_PROXY=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/systemd/system/docker.service.d/http-proxy.conf";
+
+    apply_systemd_proxy = "echo Environment=HTTPS_PROXY=" + proxy_list["https_proxy"] + " | tee -a /etc/systemd/system/docker.service.d/http-proxy.conf";
     system(apply_systemd_proxy.c_str());
-    
-    apply_systemd_proxy = "echo Environment=HTTP_PROXY=" + proxy_list["https_proxy"] + " | sudo tee -a /etc/systemd/system/docker.service.d/http-proxy.conf";
+
+    apply_systemd_proxy = "echo Environment=HTTP_PROXY=" + proxy_list["https_proxy"] + " | tee -a /etc/systemd/system/docker.service.d/http-proxy.conf";
     system(apply_systemd_proxy.c_str());
-    
-    apply_systemd_proxy = "echo Environment=NO_PROXY=" + proxy_list["no_proxy"] + " | sudo tee -a /etc/systemd/system/docker.service.d/http-proxy.conf";
+
+    apply_systemd_proxy = "echo Environment=NO_PROXY=" + proxy_list["no_proxy"] + " | tee -a /etc/systemd/system/docker.service.d/http-proxy.conf";
     system(apply_systemd_proxy.c_str());
-    
+
     // Flush changes, Re-load Daemon and Re-Start Docker
-    string str = "sudo systemctl daemon-reload";
+    string str = "systemctl daemon-reload";
     const char *command = str.c_str();
     system(command);
-     
-    str = "sudo systemctl restart docker";
+
+    str = "systemctl restart docker";
     command = str.c_str();
     system(command);
 }
@@ -76,15 +76,15 @@ void apply_docker_proxy() {
 void Settings::set_proxy(QString https_proxy, QString no_proxy) {
     Settings::_https_proxy=https_proxy;
     Settings::_no_proxy=no_proxy;
-        
+
     cout << "Setting https_proxy to " << https_proxy.toStdString() << endl;
     cout << "Setting no_proxy to " << no_proxy.toStdString() << endl;
 
     proxy_list["https_proxy"] = https_proxy.toStdString();
     proxy_list["no_proxy"] = no_proxy.toStdString();
-    
+
     apply_docker_proxy();
     set_environment_variables();
-    
+
     cout << "Applied Proxy Settings!" << endl;
 }

--- a/backend/stats.cpp
+++ b/backend/stats.cpp
@@ -12,7 +12,7 @@
 
 QString stats::getgpuload() {
     QProcess process;
-    process.start("sudo cat /sys/kernel/debug/pvr/status");
+    process.start("cat /sys/kernel/debug/pvr/status");
     process.waitForFinished(-1);
     QString output = process.readAllStandardOutput();
     return output.mid(output.indexOf("GPU Utilisation")+17,output.indexOf("%")-output.indexOf("GPU Utilisation")-17);
@@ -31,7 +31,7 @@ QString stats::get_soc_temp() {
     QString output;
     float temp = 0;
 
-    process.start("sudo cat /sys/class/thermal/thermal_zone0/temp");
+    process.start("cat /sys/class/thermal/thermal_zone0/temp");
     process.waitForFinished(-1);
     temp = process.readAllStandardOutput().toFloat();
 


### PR DESCRIPTION
Using sudo every second to get gpu load and soc temperature is causing journalctl to be flooded with sudo logs. Also, using sudo is not needed because the ti-apps-launcher itself is run as root user. So remove sudo.