### PR TITLE
configs: Update Seva Store Command for all platforms

### DIFF
--- a/configs/am62pxx-evm.cpp
+++ b/configs/am62pxx-evm.cpp
@@ -90,8 +90,7 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-QString seva_command = QString::fromStdString("seva-launcher-aarch64");
-RunCmd *seva_store = new RunCmd(seva_command);
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
 RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));

--- a/configs/am62xx-evm.cpp
+++ b/configs/am62xx-evm.cpp
@@ -89,8 +89,7 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-QString seva_command = QString::fromStdString("seva-launcher-aarch64");
-RunCmd *seva_store = new RunCmd(seva_command);
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
 RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));

--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -84,8 +84,7 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-QString seva_command = QString::fromStdString("seva-launcher-aarch64");
-RunCmd *seva_store = new RunCmd(seva_command);
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
 RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));

--- a/configs/am68-sk.cpp
+++ b/configs/am68-sk.cpp
@@ -66,8 +66,7 @@ LiveCamera live_camera;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-QString seva_command = QString::fromStdString("seva-launcher-aarch64");
-RunCmd *seva_store = new RunCmd(seva_command);
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
 RunCmd *sdk_datasheet = new RunCmd(QStringLiteral("docker run -v /run/user/1000/:/tmp/ -i --env http_proxy --env https_proxy --env no_proxy --env XDG_RUNTIME_DIR=/tmp/ --env WAYLAND_DISPLAY=wayland-1 -u user ghcr.io/texasinstruments/seva-browser:v1.0.0 https://software-dl.ti.com/jacinto7/esd/processor-sdk-linux-am68/latest/exports/docs/devices/J7_Family/linux/Release_Specific_Performance_Guide.html"));
 
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));

--- a/configs/am69-sk.cpp
+++ b/configs/am69-sk.cpp
@@ -66,8 +66,7 @@ LiveCamera live_camera;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-QString seva_command = QString::fromStdString("seva-launcher-aarch64");
-RunCmd *seva_store = new RunCmd(seva_command);
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
 RunCmd *sdk_datasheet = new RunCmd(QStringLiteral("docker run -v /run/user/1000/:/tmp/ -i --env http_proxy --env https_proxy --env no_proxy --env XDG_RUNTIME_DIR=/tmp/ --env WAYLAND_DISPLAY=wayland-1 -u user ghcr.io/texasinstruments/seva-browser:v1.0.0 https://software-dl.ti.com/jacinto7/esd/processor-sdk-linux-am69/latest/exports/docs/devices/J7_Family/linux/Release_Specific_Performance_Guide.html"));
 
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));


### PR DESCRIPTION
- With GPU accelerated Chromium Browser integrated in SDK 9.2 release [1], seva-launcher-aarch64 will be responsible to create a localhost page on port 8000 [2].

- Hence, update seva-store command for all platforms to launch Chromium Browser with http://localhost:8000/#/ once user clicks Seva Store on ti-apps-launcher.

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=kirkstone&id=1c7e65c70d3d0648274b9945a94dc8a3b69e5b94

[2]: https://git.ti.com/cgit/ti-sdk-linux/meta-tisdk/commit/?h=kirkstone&id=0b32034480906ea67f5a7ef80b01590abedd89f6