### PR TITLE
configs: Modify RunCmd for seva_store & chromium_browser for SITARA

### DIFF
--- a/configs/am62pxx-evm.cpp
+++ b/configs/am62pxx-evm.cpp
@@ -90,10 +90,10 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
-RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));
+RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run https://webglsamples.org/aquarium/aquarium.html\""));
 
 void platform_setup(QQmlApplicationEngine *engine) {
     std::cout << "Running Platform Setup of AM62P!" << endl;

--- a/configs/am62xx-evm.cpp
+++ b/configs/am62xx-evm.cpp
@@ -89,10 +89,10 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
-RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));
+RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run https://webglsamples.org/aquarium/aquarium.html\""));
 
 void platform_setup(QQmlApplicationEngine *engine) {
     std::cout << "Running Platform Setup of AM62x!" << endl;

--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -84,10 +84,10 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
-RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));
+RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run https://webglsamples.org/aquarium/aquarium.html\""));
 
 void platform_setup(QQmlApplicationEngine *engine) {
     std::cout << "Running Platform Setup of AM62x LP EVM!" << endl;

--- a/configs/beagleplay.cpp
+++ b/configs/beagleplay.cpp
@@ -89,10 +89,10 @@ ArmAnalytics arm_analytics;
 Benchmarks benchmarks;
 Gpu_performance gpuperformance;
 
-RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium http://localhost:8000/#/\""));
+RunCmd *seva_store = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run http://localhost:8000/#/\""));
 RunCmd *demo_3d = new RunCmd(QStringLiteral("/usr/bin/SGX/demos/Wayland/OpenGLESSkinning"));
 RunCmd *poweraction = new RunCmd(QStringLiteral(""));
-RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium https://webglsamples.org/aquarium/aquarium.html\""));
+RunCmd *chromium_browser = new RunCmd(QStringLiteral("su weston -c \"chromium --no-first-run https://webglsamples.org/aquarium/aquarium.html\""));
 
 void platform_setup(QQmlApplicationEngine *engine) {
     std::cout << "Running Platform Setup of Beagleplay!" << endl;


### PR DESCRIPTION
- For SDK 10.0, Chromium has be upgraded to v123 [1]. With Chromium v123 it's observed that it auto launches a "Welcome to Chrome" tab on it's first run.

- To prevent it, use --no-first-run flag while launching Chromium to ensure a smoother OOB experience of Seva Store & WebGL Aquarium Demo.

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=2ac8e1bc67f9562a2670d2accf23d01c4508509f