### PR TITLE
wifi: Add previousWifiOn property to track Wifi state changes

### DIFF
--- a/apps/wifi.qml
+++ b/apps/wifi.qml
@@ -15,8 +15,6 @@ Rectangle {
     height: parent.height
     color: "#344045"
 
-    property bool previousWifiOn: wifi.wifiOn
-
     // toggle switch
     Rectangle {
         id: toggle
@@ -67,13 +65,12 @@ Rectangle {
             }
             onClicked: {
                 wifi.toggle()
-                if (!wifi.wifiOn && !previousWifiOn) {
+                if (!wifi.wifiOn && !wifi.previousWifiOn) {
                     wifiErrorMessage.visible = true
                 } else {
                     wifiErrorMessage.visible = false
                     connection_status.text = ""
                 }
-                previousWifiOn = wifi.wifiOn
             }
         }
     }

--- a/backend/includes/wifi.h
+++ b/backend/includes/wifi.h
@@ -15,6 +15,7 @@ class Wifi : public QObject {
     Q_PROPERTY(bool wifiOn READ wifiOn NOTIFY wifiOnChanged)
     Q_PROPERTY(bool wifiConnected READ wifiConnected NOTIFY wifiConnectedChanged)
     Q_PROPERTY(QString ssid READ ssid NOTIFY ssidChanged)
+    Q_PROPERTY(bool previousWifiOn READ previousWifiOn NOTIFY previousWifiOnChanged)
 
 public:
     Q_INVOKABLE explicit Wifi();
@@ -23,6 +24,7 @@ public:
     Q_INVOKABLE void fetchSSIDNames();
     Q_INVOKABLE QStringList getSSIDList();
     Q_INVOKABLE bool wifiOn();
+    Q_INVOKABLE bool previousWifiOn();
     Q_INVOKABLE bool wifiConnected();
     Q_INVOKABLE void toggle();
     Q_INVOKABLE void setWifiOn();
@@ -38,10 +40,12 @@ signals:
     void ssidListChanged();  // Signal to notify QML of ssid List changes
     void wifiConnectedChanged(); // Signal to notify QML of wifi connection changes
     void ssidChanged(); // Signal to notify QML of ssid changes
+    void previousWifiOnChanged(); // Signal to notify QML of previouswifistatus
 
 private:
     vector<string> ssidVector;  // Vector to store SSID names
     QString m_ssid; // Store SSID
     bool m_wifiOn; // Store wifi status
     bool m_wifiConnected; // Store wifi connect status
+    bool m_previousWifiOn; // Store previous wifi status
 };

--- a/backend/wifi.cpp
+++ b/backend/wifi.cpp
@@ -13,12 +13,18 @@ using namespace std;
 Wifi::Wifi() {
     m_wifiOn = false;
     m_wifiConnected = false;
+    m_previousWifiOn = false;
     checkWifiState();
 }
 
 // Method to return wifi status
 bool Wifi::wifiOn() {
     return m_wifiOn;
+}
+
+// Method to return previous wifi status
+bool Wifi::previousWifiOn() {
+    return m_previousWifiOn;
 }
 
 // Method to return wifi connection
@@ -40,10 +46,12 @@ void Wifi::toggle() {
     // wait for 2 sec to before checking wifi status
     sleep(2);
     bool currentState = checkWifiOnState();
+    m_previousWifiOn = m_wifiOn;
     if(currentState!=m_wifiOn) {
         m_wifiOn = currentState;
     }
     emit wifiOnChanged();
+    emit previousWifiOnChanged();
 }
 
 // Method to switch on wifi


### PR DESCRIPTION
Remove previousWifiOn property from QML and add it to backend. The backend implementation ensures that previousWifiOn persists across apps and does not reset when switching apps or demos. Also implement getter functions amd change notifications for previousWifiOn in the backend.
