### PR TITLE
Remove suspend button for RT linux build

### DIFF
--- a/configs/am62pxx-evm.cpp
+++ b/configs/am62pxx-evm.cpp
@@ -16,7 +16,12 @@ using namespace std;
 QString platform = "am62pxx-evm";
 QString wallpaper = "file:///opt/ti-apps-launcher/assets/am6x_oob_demo_home_image.png";
 
+#if RT_BUILD == 1
+int include_powerbuttons_count = 2;
+#else
 int include_powerbuttons_count = 3;
+#endif
+
 power_actions include_powerbuttons[] = {
     {
         .name = "Shutdown",

--- a/configs/am62xx-evm.cpp
+++ b/configs/am62xx-evm.cpp
@@ -15,7 +15,12 @@ using namespace std;
 QString platform = "am62xx-evm";
 QString wallpaper = "file:///opt/ti-apps-launcher/assets/am6x_oob_demo_home_image.png";
 
+#if RT_BUILD == 1
+int include_powerbuttons_count = 2;
+#else
 int include_powerbuttons_count = 3;
+#endif
+
 power_actions include_powerbuttons[] = {
     {
         .name = "Shutdown",

--- a/configs/am62xx-lp-evm.cpp
+++ b/configs/am62xx-lp-evm.cpp
@@ -14,7 +14,12 @@ using namespace std;
 QString platform = "am62xx-lp-evm";
 QString wallpaper = "file:///opt/ti-apps-launcher/assets/am6x_oob_demo_home_image.png";
 
+#if RT_BUILD == 1
 int include_powerbuttons_count = 2;
+#else
+int include_powerbuttons_count = 3;
+#endif
+
 power_actions include_powerbuttons[] = {
     {
         .name = "Shutdown",
@@ -25,6 +30,11 @@ power_actions include_powerbuttons[] = {
         .name = "Reboot",
         .command = "reboot",
         .icon_source = "file:///opt/ti-apps-launcher/assets/reboot.png",
+    },
+    {
+        .name = "Suspend",
+        .command = "/opt/ti-apps-launcher/suspend",
+        .icon_source = "file:///opt/ti-apps-launcher/assets/suspend.png",
     }
 };
 


### PR DESCRIPTION
Low power mode is not supported on RT Linux. So drop suspend button from ti-apps-launcher for RT Linux image build. To achieve this add a new RT_BUILD flag which when enabled does not includes the suspend button during qmake. After this change, ti-apps-launcher for RT Linux build should be build with RT_BUILD=1.

Also add suspend button for am62lp config.