### PR TITLE
Remove unneeded QML module imports

### DIFF
--- a/apps/3d_demo.qml
+++ b/apps/3d_demo.qml
@@ -1,13 +1,8 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Rectangle {
     id: demo3d
     visible: true

--- a/apps/appsmenu.qml
+++ b/apps/appsmenu.qml
@@ -1,14 +1,7 @@
 import QtQml 2.1
 import QtQuick 2.14
 import QtMultimedia 5.1
-import QtQuick.Window 2.14
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Styles 1.2
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
 import QtQuick.Controls 2.15
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Rectangle {
@@ -88,11 +81,18 @@ Rectangle {
                             }
                         }
 
-                        layer.enabled: true
-                        layer.effect: DropShadow {
-                            transparentBorder: true
-                            horizontalOffset: height * 0.15
-                            verticalOffset: height * 0.15
+                        Rectangle {
+                            id: dropShadowRect
+                            color: "black"
+                            width: parent.width
+                            height: parent.height
+                            z: -1
+                            opacity: 0.75
+                            radius: 2
+                            anchors.left: parent.left
+                            anchors.leftMargin: height * 0.15
+                            anchors.top: parent.top
+                            anchors.topMargin: height * 0.15
                         }
 
                         onClicked: {

--- a/apps/arm_analytics.qml
+++ b/apps/arm_analytics.qml
@@ -1,13 +1,9 @@
 import QtQml 2.1
 import QtQuick 2.14
 import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Rectangle {
     id: arm_analytics_app
     visible: true

--- a/apps/auto_cluster.qml
+++ b/apps/auto_cluster.qml
@@ -1,13 +1,10 @@
 import QtQuick 2.15
 import QtQuick.Extras 1.4
-import QtQuick.Window 2.15
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
 import QtQuick.Shapes 1.15
 import QtGraphicalEffects 1.12
-
-
 
 Rectangle {
     width: 1920

--- a/apps/benchmarks.qml
+++ b/apps/benchmarks.qml
@@ -1,19 +1,13 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Rectangle {
     id: button2window
     visible: true
-    height: Screen.desktopAvailableHeight * 0.6
-    width: Screen.desktopAvailableWidth * 0.825
+    height: parent.height
+    width: parent.width
     color: "#344045"
     Rectangle{
         id: gpu_benchmarks
@@ -414,10 +408,9 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
 
-        textFormat: Text.MarkdownText
-        text: "**Note:** The glmark2 window doesn't have a titlebar. Hence it cannot be moved around by dragging the window when using Touch controls.\n
-To stop the glmark2 before it ends, click outside of the glmark2 window on ti-apps-launcher window and click stop icon.\n
-A mouse can still be used as an alternative to move it around."
+        text: "**Note:** The glmark2 window doesn't have a titlebar. Hence it cannot be moved around by dragging the window when using Touch controls.\n" +
+              "To stop the glmark2 before it ends, click outside of the glmark2 window on ti-apps-launcher window and click stop icon.\n" +
+              "A mouse can still be used as an alternative to move it around."
         color: "red"
 
         font.pixelSize: parent.width * 0.015

--- a/apps/benchmarks_jacinto.qml
+++ b/apps/benchmarks_jacinto.qml
@@ -1,19 +1,13 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Rectangle {
     id: button2window
     visible: true
-    height: Screen.desktopAvailableHeight * 0.6
-    width: Screen.desktopAvailableWidth * 0.825
+    height: parent.height
+    width: parent.width
     color: "#344045"
     Rectangle{
         id: gpu_benchmarks

--- a/apps/camera.qml
+++ b/apps/camera.qml
@@ -1,12 +1,8 @@
 import QtQml 2.1
 import QtQuick 2.14
 import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
 import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Rectangle {

--- a/apps/chromium_browser.qml
+++ b/apps/chromium_browser.qml
@@ -1,12 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Rectangle {

--- a/apps/codecs.qml
+++ b/apps/codecs.qml
@@ -1,13 +1,9 @@
 import QtQml 2.1
 import QtQuick 2.14
 import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Rectangle {
     id: codecs
     visible: true

--- a/apps/deviceinfo.qml
+++ b/apps/deviceinfo.qml
@@ -1,10 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
 
 Rectangle {
     width: parent.width

--- a/apps/gpu_performance.qml
+++ b/apps/gpu_performance.qml
@@ -1,21 +1,10 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
-import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
-
 
 Rectangle {
     id: gpuperformancewindow
     visible: true
-    // height: Screen.desktopAvailableHeight * 0.6
-    // width: Screen.desktopAvailableWidth * 0.825
     height: parent.height
     width: parent.width
     

--- a/apps/industrial_control.qml
+++ b/apps/industrial_control.qml
@@ -1,17 +1,15 @@
 import QtQuick 2.2
-import QtQuick.Window 2.14
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 import QtQuick.Extras.Private 1.0
 import QtGraphicalEffects 1.12
-import QtMultimedia 5.1
 
 Rectangle{
     id: window
-    height: Screen.desktopAvailableHeight * 0.6
-    width: Screen.desktopAvailableWidth * 0.825
+    height: parent.height
+    width: parent.width
     Rectangle {
         id: backgroundrect
         width: window.width

--- a/apps/industrial_control_minimal.qml
+++ b/apps/industrial_control_minimal.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.14
-import QtQuick.Window 2.14
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3

--- a/apps/industrial_control_sitara.qml
+++ b/apps/industrial_control_sitara.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
 import QtQuick.Extras 1.4
-import QtQuick.Window 2.15
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3

--- a/apps/live_camera.qml
+++ b/apps/live_camera.qml
@@ -1,13 +1,9 @@
 import QtQml 2.1
 import QtQuick 2.14
 import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Rectangle {
     id: camerarecorder
     visible: true

--- a/apps/settings.qml
+++ b/apps/settings.qml
@@ -1,13 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Rectangle {

--- a/apps/seva_store.qml
+++ b/apps/seva_store.qml
@@ -1,13 +1,6 @@
-import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
-import QtQuick.Layouts 1.3
+
 Rectangle {
     id: seva
     visible: true

--- a/apps/stats.qml
+++ b/apps/stats.qml
@@ -1,13 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Rectangle {

--- a/apps/topbar.qml
+++ b/apps/topbar.qml
@@ -1,10 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
 import QtQuick.Layouts 1.15
 
 Rectangle {

--- a/apps/wifi.qml
+++ b/apps/wifi.qml
@@ -1,13 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
-import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Rectangle {

--- a/ti-apps-launcher.qml
+++ b/ti-apps-launcher.qml
@@ -1,14 +1,9 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
 import QtQuick.Window 2.14
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.12
-import Qt.labs.folderlistmodel 2.4
-
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
+
 Window {
     visible: true
     visibility: "FullScreen"


### PR DESCRIPTION
Like header files in C, we should only import what we need in QML. Several of these unneeded imported modules are no longer available in Qt6, so this helps with the migration.