### PR TITLE
Initial Qt6 migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 include(GNUInstallDirs)
 
-#find_package(QT NAMES Qt5 Qt6 REQUIRED COMPONENTS Core)
-find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Widgets Multimedia Quick)
 
 set(SOURCES

--- a/apps/appsmenu.qml
+++ b/apps/appsmenu.qml
@@ -1,6 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
+import QtMultimedia
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.3
 

--- a/apps/arm_analytics.qml
+++ b/apps/arm_analytics.qml
@@ -1,6 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
+import QtMultimedia
 import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
@@ -13,13 +13,12 @@ Rectangle {
 
     MediaPlayer {
         id: mediaplayer
-        autoPlay: false
+        videoOutput: analytics_feed
     }
 
     VideoOutput {
         id: analytics_feed
         anchors.fill: parent
-        source: mediaplayer
 
         RowLayout {
             id: analytics_buttons

--- a/apps/auto_cluster.qml
+++ b/apps/auto_cluster.qml
@@ -1,10 +1,8 @@
 import QtQuick 2.15
-import QtQuick.Extras 1.4
 import QtQuick.Controls 2.2
-import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
 import QtQuick.Shapes 1.15
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     width: 1920

--- a/apps/camera.qml
+++ b/apps/camera.qml
@@ -1,6 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
+import QtMultimedia
 import QtQuick.Controls 2.1
 import Qt.labs.folderlistmodel 2.4
 import QtQuick.Layouts 1.3
@@ -18,12 +18,14 @@ Rectangle {
 
         MediaPlayer {
             id: mediaplayer
-            autoPlay: false
-            onStopped: {
-                msg.visible = msg.state
-                status_message.text = msg.state ? (" ") : ("Live: " + camera.get_current_camera())
-                camera_record_button.source = msg.state ? "/images/record-disabled.png" : "/images/record.png"
-                camera_record_button_mousearea.enabled = msg.state ? false : true
+            videoOutput: feed
+            onPlaybackStateChanged: {
+                if (playbackState !== PlayingState) {
+                    msg.visible = msg.state
+                    status_message.text = msg.state ? (" ") : ("Live: " + camera.get_current_camera())
+                    camera_record_button.source = msg.state ? "/images/record-disabled.png" : "/images/record.png"
+                    camera_record_button_mousearea.enabled = msg.state ? false : true
+                }
             }
         }
 
@@ -39,7 +41,6 @@ Rectangle {
 
             VideoOutput {
                 id: feed
-                source: mediaplayer
                 anchors.fill: parent
                 anchors.centerIn: parent
                 visible: true

--- a/apps/codecs.qml
+++ b/apps/codecs.qml
@@ -1,6 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
+import QtMultimedia
 import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 

--- a/apps/industrial_control.qml
+++ b/apps/industrial_control.qml
@@ -1,10 +1,7 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.4
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
-import QtQuick.Extras.Private 1.0
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 
 Rectangle{
     id: window

--- a/apps/industrial_control_minimal.qml
+++ b/apps/industrial_control_minimal.qml
@@ -1,6 +1,4 @@
 import QtQuick 2.14
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Extras 1.4
 import QtQuick.Layouts 1.3
 
 Item {

--- a/apps/industrial_control_sitara.qml
+++ b/apps/industrial_control_sitara.qml
@@ -1,10 +1,8 @@
 import QtQuick 2.15
-import QtQuick.Extras 1.4
 import QtQuick.Controls 2.2
-import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
 import QtQuick.Shapes 1.15
-import QtGraphicalEffects 1.12
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     anchors.fill: parent

--- a/apps/live_camera.qml
+++ b/apps/live_camera.qml
@@ -1,6 +1,6 @@
 import QtQml 2.1
 import QtQuick 2.14
-import QtMultimedia 5.1
+import QtMultimedia
 import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 

--- a/apps/terminal.qml
+++ b/apps/terminal.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QMLTermWidget 1.0
-import QtQuick.Controls 1.2
+import QtQuick.Controls 2.1
 
 Rectangle {
     anchors.fill: parent

--- a/backend/appsmenu.cpp
+++ b/backend/appsmenu.cpp
@@ -10,7 +10,7 @@ QString apps_menu::button_getname(int n) {
 }
 
 QString apps_menu::button_getqml(int n) {
-    return deviceMap[detected_device].include_apps[n].qml_source;
+    return "/apps/" + deviceMap[detected_device].include_apps[n].qml_source;
 }
 
 QString apps_menu::button_geticon(int n) {


### PR DESCRIPTION
Switch default build target to Qt6. Some sub-components are still not functional such as GStreamer based ones and the control demos.