### PR TITLE
Migrate live_camera to Qt6 and qml6glsink

### DIFF
--- a/backend/includes/live_camera.h
+++ b/backend/includes/live_camera.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QStringListModel>
 #include <QString>
+#include <gst/gst.h>
 
 class LiveCamera : public QObject {
     Q_OBJECT
@@ -15,6 +16,8 @@ private:
 
     std::string replaceAll(std::string str, const std::string &remove, const std::string &insert);
     std::string trimString(std::string str);
+
+    GstElement *pipeline = NULL;
 
 public:
 
@@ -32,6 +35,8 @@ public:
     Q_INVOKABLE QString liveCamera_gst_pipeline();
     Q_INVOKABLE int liveCamera_get_count();
     Q_INVOKABLE QString liveCamera_get_camera_name(int index);
+    Q_INVOKABLE void stopStream();
+    Q_INVOKABLE void startStream(QObject *object);
 
 signals:
 

--- a/configs/am62pxx-evm.h
+++ b/configs/am62pxx-evm.h
@@ -8,6 +8,7 @@ struct device_info device_info_am62p = {
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
         app_industrial_control_sitara,
+        app_live_camera,
         app_arm_analytics,
         app_benchmarks,
         app_gpu_performance,

--- a/configs/am62xx-evm.h
+++ b/configs/am62xx-evm.h
@@ -8,6 +8,7 @@ struct device_info device_info_am62 = {
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
         app_industrial_control_sitara,
+        app_live_camera,
         app_arm_analytics,
         app_benchmarks,
         app_gpu_performance,

--- a/configs/am62xx-lp-evm.h
+++ b/configs/am62xx-lp-evm.h
@@ -8,6 +8,7 @@ struct device_info device_info_am62_lp = {
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
         app_industrial_control_sitara,
+        app_live_camera,
         app_arm_analytics,
         app_benchmarks,
         app_gpu_performance,


### PR DESCRIPTION
This PR migrates live_camera demo to Qt6 and qml6glsink.
Originally (before 11.0), we had a different camera demo for AM62P. But that demo will be migrated in a different PR, so until then, lets have live_camera as a placeholder in AM62P too.

This PR has been tested on SK-AM62B.