### PR TITLE
configs: am6[789]-sk.h: Sync platform configs with the rest

### DIFF
--- a/configs/am67-sk.h
+++ b/configs/am67-sk.h
@@ -7,8 +7,8 @@ struct device_info device_info_am67 = {
     .platform = "am67-sk",
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
-        app_industrial_control,
-        app_camera,
+        app_industrial_control_sitara,
+        app_live_camera,
         app_benchmarks_jacinto,
         app_gpu_performance,
         app_seva_store,

--- a/configs/am68-sk.h
+++ b/configs/am68-sk.h
@@ -2,17 +2,13 @@
 
 #include "backend/includes/common.h"
 
-using namespace std;
-static QString platform = "am68-sk";
-static QString wallpaper = "/images/am6x_oob_demo_home_image.png";
-
 struct device_info device_info_am68 = {
-    .dtMatchString = "J721S2",
+    .dtMatchString = "AM68 SK",
     .platform = "am68-sk",
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
-        app_industrial_control,
-        app_camera,
+        app_industrial_control_sitara,
+        app_live_camera,
         app_benchmarks_jacinto,
         app_gpu_performance,
         app_seva_store,

--- a/configs/am69-sk.h
+++ b/configs/am69-sk.h
@@ -8,7 +8,7 @@ struct device_info device_info_am69 = {
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
         app_industrial_control_sitara,
-        app_camera,
+        app_live_camera,
         app_benchmarks_jacinto,
         app_gpu_performance,
         app_seva_store,
@@ -18,6 +18,5 @@ struct device_info device_info_am69 = {
     .include_powerbuttons = {
         action_shutdown,
         action_reboot,
-        action_suspend,
     },
 };


### PR DESCRIPTION
As part of QT6 migration, sync the Jacinto platforms with the rest... This includes some proper fixes like updating the proper dtmatch string for AM68-SK and switching to the app_industrial_control_sitara and the app_live_camera app which are the working versions of the apps. The original versions of these have not been migrated to QT6 yet.