### PR TITLE
Improve auto_cluster UI

### DIFF
--- a/apps/CircularGauge.qml
+++ b/apps/CircularGauge.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     width: 300
@@ -10,16 +11,38 @@ Item {
     property real value: 8
     property real labelStepSize: 2
     property int minorTickmarkCount: 4
+    property int majorTickmarkSize: 15
     property bool showLabel: true
+    property bool enlargeOrigin: false
+    property real opacityValue: 1.0
+    property string meterUnit: ""
+    property string gaugeLabel: ""
+
+    property string regularTickColor: "black"
+    property string alertTickColor: ""
+    property string regularLabelColor: "red"
+    property string alertLabelColor: ""
+    property string needleColor: "red"
+    property string needleOriginColor: "black"
+
+    property bool hasAlertZone: false
+    property real alertPercent_start: 0
+    property real alertPercent_end: 1
+
+    property bool hasArcZone: false
+    property real arcPercent_start: 0
+    property real arcPercent_end: 1
 
     property int labelCount: ((maximumValue - minimumValue) / labelStepSize) + 1
+    property real trueLabelStepSize: labelStepSize / (minorTickmarkCount + 1)
+    property int totalTickmarks: (labelCount - 1) * minorTickmarkCount + labelCount
 
     property int initDeg: 110 /* angle (in degrees) to the 1st major tickmark */
     property int totalDeg: 320 /* total no. of degrees that all tickmarks will span */
     /* Math.trignometricFoo()'s expect angles to be in radians, whereas QML properties like "rotation:" expect them in degrees.
      * Therefore maintain angles in both.
      */
-    property real intervalDeg: totalDeg / (labelCount - 1) /* no. of degrees b/w 2 major tickmarks */
+    property real intervalDeg: totalDeg / (totalTickmarks - 1) /* no. of degrees b/w 2 tickmarks */
     property real intervalRad: intervalDeg * Math.PI / 180 /* no. of radians b/w 2 major tickmarks */
 
     //color: "transparent"
@@ -31,15 +54,17 @@ Item {
         /* "Math.min(value, maximumValue)" ensures that we don't turn the needle beyond the last label in the circle.
          * "Math.max(angle, initDeg)" ensures that we don't turn the needle to below the first label in the circle.
          */
-        return Math.max((((Math.min(value, maximumValue) - minimumValue) / labelStepSize) * intervalDeg + initDeg), initDeg);
+        return Math.max((((Math.min(value, maximumValue) - minimumValue) / trueLabelStepSize) * intervalDeg + initDeg), initDeg);
     }
 
     Rectangle {
+        id: outerCircle
         anchors.fill: parent
         color: "#f0f0f0"  /* light-grey */
         radius: width / 2
         border.color: "black"
         border.width: 3
+        opacity: opacityValue
     }
 
     /* CircularGauge tickmarks and labels */
@@ -57,45 +82,60 @@ Item {
             ctx.textAlign = "center"
             ctx.textBaseline = "middle"
 
-            for (var i = 0; i < labelCount; i++) {
+            var alertIndex_start = Math.floor(alertPercent_start * (labelCount - 1)) * (minorTickmarkCount + 1)
+            var alertIndex_end = Math.floor(alertPercent_end * (labelCount - 1)) * (minorTickmarkCount + 1)
+            var arcIndex_start = Math.floor(arcPercent_start * (labelCount - 1)) * (minorTickmarkCount + 1)
+            var arcIndex_end = Math.floor(arcPercent_end * (labelCount -1)) * (minorTickmarkCount + 1)
+
+            for (var i = 0; i < totalTickmarks; i++) {
                 var angle = (i * intervalRad + (initDeg * Math.PI / 180)) /* Angle (in radians) from center to the label's location */
+
+                var tickmarkSize = (i % (minorTickmarkCount + 1)) ? majorTickmarkSize / 2 : majorTickmarkSize
 
                 var x1 = centerX + Math.cos(angle) * radius
                 var y1 = centerY + Math.sin(angle) * radius
-                var x2 = centerX + Math.cos(angle) * (radius - 15)
-                var y2 = centerY + Math.sin(angle) * (radius - 15)
-                var textX = centerX + Math.cos(angle) * (radius - 30)
-                var textY = centerY + Math.sin(angle) * (radius - 30)
+                var x2 = centerX + Math.cos(angle) * (radius - tickmarkSize)
+                var y2 = centerY + Math.sin(angle) * (radius - tickmarkSize)
+                var textX = centerX + Math.cos(angle) * (radius - tickmarkSize - 15)
+                var textY = centerY + Math.sin(angle) * (radius - tickmarkSize - 15)
 
+                var styleColor
+                if (hasAlertZone && i >= alertIndex_start && i <= alertIndex_end) {
+                    styleColor = alertTickColor
+                } else {
+                    styleColor = regularTickColor
+                }
                 /* Draw major tickmarks */
                 ctx.beginPath()
                 ctx.moveTo(x1, y1)
                 ctx.lineTo(x2, y2)
-                ctx.strokeStyle = "black"
+                ctx.strokeStyle = styleColor
                 ctx.lineWidth = 2
                 ctx.stroke()
 
                 /* Draw labels */
-                if (showLabel == true) {
-                    ctx.fillStyle = "red"
-                    ctx.fillText(i * labelStepSize, textX, textY)
+                if (showLabel == true && !(i % (minorTickmarkCount + 1))) {
+                    ctx.fillStyle = styleColor == alertTickColor ? alertLabelColor : regularLabelColor
+                    ctx.fillText(i * trueLabelStepSize, textX, textY)
                 }
+            }
 
-                /* Draw minor tickmarks */
-                for (var j = 1; j <= minorTickmarkCount; ++j) {
-                    if (i == labelCount - 1) {
-                        break
-                    }
-                    var minorAngle = ((j * intervalRad / (minorTickmarkCount + 1)) + angle)
-                    var mx1 = centerX + Math.cos(minorAngle) * radius
-                    var my1 = centerY + Math.sin(minorAngle) * radius
-                    var mx2 = centerX + Math.cos(minorAngle) * (radius - 7)
-                    var my2 = centerY + Math.sin(minorAngle) * (radius - 7)
+            /* create arc */
+            if (hasArcZone) {
+                var arcStartAngle = (arcIndex_start * intervalRad + (initDeg * Math.PI / 180))
+                var arcEndAngle = (arcIndex_end * intervalRad + (initDeg * Math.PI / 180))
+                ctx.beginPath()
+                ctx.strokeStyle = regularTickColor
+                ctx.arc(centerX, centerY, radius, arcStartAngle, arcEndAngle)
+                ctx.stroke()
+
+                /* override a portion of it with red */
+                if (hasAlertZone) {
+                    arcStartAngle = (alertIndex_start * intervalRad + (initDeg * Math.PI / 180))
+                    arcEndAngle = (alertIndex_end * intervalRad + (initDeg * Math.PI / 180))
                     ctx.beginPath()
-                    ctx.moveTo(mx1, my1)
-                    ctx.lineTo(mx2, my2)
-                    ctx.strokeStyle = "black"
-                    ctx.lineWidth = 2
+                    ctx.strokeStyle = alertTickColor
+                    ctx.arc(centerX, centerY, radius, arcStartAngle, arcEndAngle)
                     ctx.stroke()
                 }
             }
@@ -107,7 +147,7 @@ Item {
         width: 4
         height: parent.width * 0.35
         radius: 2
-        color: "red"
+        color: needleColor
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.verticalCenter // Ensures it extends only upwards
         transformOrigin: Item.Bottom
@@ -118,10 +158,43 @@ Item {
 
     /* Needle Origin */
     Rectangle {
-        width: 12
-        height: 12
-        color: "black"
-        radius: 6
+        id: needleOrigin
+        width: enlargeOrigin ? outerCircle.width / 4 : 12
+        height: enlargeOrigin ? outerCircle.height / 4 : 12
+        color: needleOriginColor
+        radius: enlargeOrigin ? outerCircle.radius / 4 : 6
         anchors.centerIn: parent
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 4
+            visible: enlargeOrigin
+
+            Label {
+                text: Math.floor(value) < 0 ? 0 : Math.floor(value)
+                font.pointSize: 28
+                font.bold: true
+                color: "black"
+                Layout.alignment: Qt.AlignHCenter
+            }
+
+            Label {
+                text: meterUnit
+                font.pointSize: 10
+                color: "black"
+                Layout.alignment: Qt.AlignHCenter
+            }
+        }
+    }
+
+    Text {
+        text: "Fuel"
+        visible: gaugeLabel.length != 0
+        font.pointSize: 14
+        font.bold: true
+        color: "white"
+        anchors.top: needleOrigin.bottom
+        anchors.topMargin: (outerCircle.height * 0.15)
+        anchors.horizontalCenter: parent.horizontalCenter
     }
 }

--- a/apps/auto_cluster.qml
+++ b/apps/auto_cluster.qml
@@ -38,6 +38,24 @@ Rectangle {
         maximumValue: 160
 		labelStepSize: 20
         value: 0
+        enlargeOrigin: true
+        opacityValue: 0.0
+        meterUnit: "Kmph"
+
+        regularTickColor: "white"
+        alertTickColor: "red"
+        regularLabelColor: "white"
+        alertLabelColor: "red"
+        needleColor: "#F1C40F"
+        needleOriginColor: "#e5e5e5"
+
+        hasAlertZone: true
+        alertPercent_start: 0.625
+        alertPercent_end: 1.0
+
+        hasArcZone: true
+        arcPercent_start: 0.625
+        arcPercent_end: 1.0
 
         Behavior on value {
             SpringAnimation {
@@ -61,6 +79,24 @@ Rectangle {
         maximumValue: 8000
 		labelStepSize: 1000
         value: 0
+        enlargeOrigin: true
+        opacityValue: 0.0
+        meterUnit: "RPM"
+
+        regularTickColor: "white"
+        alertTickColor: "red"
+        regularLabelColor: "white"
+        alertLabelColor: "red"
+        needleColor: "#F1C40F"
+        needleOriginColor: "#e5e5e5"
+
+        hasAlertZone: true
+        alertPercent_start: 0.625
+        alertPercent_end: 1.0
+
+        hasArcZone: true
+        arcPercent_start: 0.625
+        arcPercent_end: 1.0
 
         Behavior on value {
             SpringAnimation {
@@ -126,7 +162,27 @@ Rectangle {
         maximumValue: 20
         value: 0
         showLabel: false
-        labelStepSize: 10
+        labelStepSize: 2
+        opacityValue: 0.0
+        minorTickmarkCount: 0
+        majorTickmarkSize: 7
+        gaugeLabel: "Fuel"
+
+        regularTickColor: "white"
+        alertTickColor: "red"
+        regularLabelColor: "white"
+        alertLabelColor: "red"
+        needleColor: "#F1C40F"
+        needleOriginColor: "#e5e5e5"
+
+        hasAlertZone: true
+        alertPercent_start: 0.0
+        alertPercent_end: 0.25
+
+        hasArcZone: true
+        arcPercent_start: 0
+        arcPercent_end: 1
+
         Behavior on value {
             NumberAnimation {
                 duration: 5000


### PR DESCRIPTION
Display cluster UI looks pretty bad at the moment. So this PR improves it. 

With this PR, the auto_cluster UI goes back to being very similar to how it used to be in 10.1 release.

An exception is the RadialGradient, which is still commented out. When run with qmlscene on PC, RadialGradient works fine. But when run on board with OLDI display, it casts a black shadow from the top-left of the screen to the bottom center.

As a result, it continues to be commented out. So the blue shade on the corners of the screen aren't there.