### PR TITLE
qt6-migration: camera: Use GStreamer for starting/stopping camera

### DIFF
--- a/backend/includes/camera.h
+++ b/backend/includes/camera.h
@@ -1,9 +1,11 @@
 #include <QObject>
 #include <QStringListModel>
 #include <QString>
+#include <QQuickItem>
 
 #include <map>
 #include <string>
+#include <gst/gst.h>
 
 class Camera : public QObject {
     Q_OBJECT
@@ -12,6 +14,7 @@ private:
 
     std::map<std::string, std::map<std::string,std::string>> cameraInfo;
     QString _videofile;
+    GstElement *pipeline;
 
     std::string replaceAll(std::string str, const std::string &remove, const std::string &insert);
     std::string trimString(std::string str);
@@ -44,11 +47,17 @@ public:
     Q_INVOKABLE QString play_camera(QString camera);
     Q_INVOKABLE QString record_camera(QString camera);
 
+    Q_INVOKABLE void stopStream();
+    Q_INVOKABLE void startStream(QObject *object);
+
+    static gboolean busCall(GstBus *bus, GstMessage *msg, gpointer data);
+
 signals:
 
     void gst_pipeline_updated();
     void count_changed();
     void filename_changed();
     void current_camera_changed();
+    void videoPlayFinished();
 };
 

--- a/configs/am62pxx-evm.h
+++ b/configs/am62pxx-evm.h
@@ -8,7 +8,7 @@ struct device_info device_info_am62p = {
     .wallpaper = "/images/am6x_oob_demo_home_image.png",
     .include_apps = {
         app_industrial_control_sitara,
-        app_live_camera,
+        app_camera,
         app_arm_analytics,
         app_benchmarks,
         app_gpu_performance,


### PR DESCRIPTION
From Qt6, MediaPlayer cannot run GStreamer pipelines on its own anymore. Therefore introduce methods `startStream()` and `stopStream()` to do so.

Further, re-enable camera in AM62P. It had been replaced with live_camera earlier.

With this commit, playing the camera, video recording and video playing work again.

Note: GstBus is used to monitor when the video playing pipeline has finished running, so that it can trigger a signal to re-enable the chosen camera and recording button.

Tested this on AM62P with USB camera.