### PR TITLE
beagleplay: Remove terminal

### DIFF
--- a/configs/beagleplay.h
+++ b/configs/beagleplay.h
@@ -16,7 +16,6 @@ struct device_info device_info_beagleplay = {
         app_chromium_browser,
         app_3d_demo,
         app_settings,
-        app_terminal,
     },
     .include_powerbuttons = {
         action_shutdown,


### PR DESCRIPTION
Terminal is not functional at the moment. Its been removed from other devices already but it was missed for Beagleplay. So remove it from here as well.