### PR TITLE
backend: Use mmap capture mode for display pipelines on AM62P

### DIFF
--- a/backend/arm_analytics.cpp
+++ b/backend/arm_analytics.cpp
@@ -61,7 +61,7 @@ void ArmAnalytics::startVideo(QObject* object) {
     }
 
     if (detected_device == AM62PXX_EVM) {
-        gst_pipeline.replace("avdec_h264", "v4l2h264dec capture-io-mode=4");
+        gst_pipeline.replace("avdec_h264", "v4l2h264dec capture-io-mode=2");
         gst_pipeline.replace("loop=true", "loop=true caps=video/x-h264,width=1280,height=720,framerate=1/1");
     }
 

--- a/backend/camera.cpp
+++ b/backend/camera.cpp
@@ -124,6 +124,7 @@ void Camera::update_codec(bool codec_choice) {
 }
 
 QString Camera::record_camera(QString camera) {
+    gst_pipeline = "";
     _camera = camera;
     QString time_format = "yyyy_MM_dd-HH_mm_ss";
     QDateTime time = QDateTime::currentDateTime();
@@ -159,6 +160,7 @@ QString Camera::record_camera(QString camera) {
 }
 
 QString Camera::play_camera(QString camera) {
+    gst_pipeline = "";
     _camera = camera;
     gst_pipeline.append("v4l2src device=");
     gst_pipeline.append(QString::fromStdString((cameraInfo[_camera.toStdString()]["device"])));
@@ -183,6 +185,7 @@ QString Camera::get_gst_pipeline() {
 }
 
 QString Camera::play_video(QString videofile) {
+    gst_pipeline = "";
     _videofile = videofile;
     filename = _videofile;
     emit filename_changed();
@@ -197,7 +200,7 @@ QString Camera::play_video(QString videofile) {
     gst_pipeline.append(codec);
     gst_pipeline.append("parse ! v4l2");
     gst_pipeline.append(codec);
-    gst_pipeline.append("dec capture-io-mode=dmabuf ! videoconvert ! glupload ! qml6glsink name=sink sync=true");
+    gst_pipeline.append("dec capture-io-mode=mmap ! videoconvert ! glupload ! qml6glsink name=sink");
     qDebug() << "New Gst Pipeline: " << gst_pipeline;
     return gst_pipeline;
 }


### PR DESCRIPTION
Replace dmabuf (capture-io-mode=4) with mmap (capture-io-mode=2) for v4l2h264dec in display-only pipelines. This properly matches qml6glsink's input requirements (CPU-accessible I420 format instead of GPU memory DMA_DRM).