### PR TITLE
feat: Add window mode configuration via environment variable

### DIFF
--- a/ti-apps-launcher.cpp
+++ b/ti-apps-launcher.cpp
@@ -93,7 +93,14 @@ int main(int argc, char *argv[]) {
     }
     modelNamesList.setStringList(modelslist);
 
+    // Check if windowed mode is requested via environment variable
+    QString windowMode = qgetenv("TI_APPS_WINDOW_MODE");
+    if (windowMode.isEmpty()) {
+        windowMode = "FullScreen";  // Default to fullscreen
+    }
+
     // set context properties to access in QML
+    engine.rootContext()->setContextProperty("windowMode", windowMode);
     engine.rootContext()->setContextProperty("modelNamesList", &modelNamesList);
     engine.rootContext()->setContextProperty("appsmenu", &appsmenu);
     engine.rootContext()->setContextProperty("powermenu", &powermenu);

--- a/ti-apps-launcher.qml
+++ b/ti-apps-launcher.qml
@@ -6,8 +6,10 @@ import QtQuick.Layouts 1.3
 
 Window {
     visible: true
-    visibility: "FullScreen"
+    visibility: windowMode
     title: qsTr("TI Apps Launcher")
+    width: 1280
+    height: 720
 
     Rectangle {
         id: appBackground


### PR DESCRIPTION
Add support for controlling the ti-apps-launcher window mode (FullScreen, Windowed, Maximized) at runtime using the TI_APPS_WINDOW_MODE environment variable, without requiring recompilation.

Changes:
 - Read TI_APPS_WINDOW_MODE environment variable in C++ (defaults to FullScreen)
 - Pass windowMode to QML as a context property
 - Set window visibility dynamically based on windowMode value
 - Set default window dimensions (1280x720) for windowed modes

Usage in systemd service:
  Environment=TI_APPS_WINDOW_MODE=Windowed    # or Maximized, FullScreen